### PR TITLE
tagpreview patch (todo fix motionnotify)

### DIFF
--- a/config.h
+++ b/config.h
@@ -20,6 +20,7 @@ static       int linepx             = 2;        /* 0 means no underline */
 static const int vertpad            = 0;       /* vertical padding of bar */
 static const int sidepad            = 0;       /* horizontal padding of bar */
 static const int statuspad          = 8;
+static const int scalepreview       = 4;        /* Tag preview scaling */
 static const int nmaxmaster         = 3;        /* maximum number of clients allowed in master area */
 static const int user_bh            = 28;       /* 0 means that dwm will calculate bar height, >= 1 means dwm will user_bh as bar height */
 static const int pertag             = 1;

--- a/hydra.c
+++ b/hydra.c
@@ -70,6 +70,8 @@
 #define TAGSLENGTH              (LENGTH(tags))
 #define TEXTW(X)                (drw_fontset_getwidth(drw, (X)) + lrpad)
 
+#define NUMTAGS 				7
+
 #define OPAQUE                  0xffU
 
 #define SYSTEM_TRAY_REQUEST_DOCK    0
@@ -180,6 +182,9 @@ struct Monitor {
 	Client *stack;
 	Monitor *next;
 	Window barwin;
+	Window tagwin;
+	int previewshow;
+	Pixmap tagmap[NUMTAGS];
 	const Layout *lt[2];
 	Pertag *pertag;
 };
@@ -281,12 +286,15 @@ static void setup(void);
 static void setviewport(void);
 static void seturgent(Client *c, int urg);
 static void showhide(Client *c);
+static void showtagpreview(int tag, int x, int y);
+static void hidetagpreview(Monitor *m);
 static void sigchld(int unused);
 static void sighydrablocks(const Arg *arg);
 static void spawn(const Arg *arg);
 static pid_t spawncmd(const Arg *arg);
 static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
+static void tagpreviewswitchtag(void);
 static void togglebar(const Arg *arg);
 static void togglefloating(const Arg *arg);
 static void togglefullscr(const Arg *arg);
@@ -310,6 +318,7 @@ static void updatetitle(Client *c);
 static void updateicon(Client *c);
 static void updatewindowtype(Client *c);
 static void updatewmhints(Client *c);
+static void updatepreview(void);
 static void view(const Arg *arg);
 static Client *wintoclient(Window w);
 static Monitor *wintomon(Window w);
@@ -662,6 +671,11 @@ cleanupmon(Monitor *mon)
 		for (m = mons; m && m->next != mon; m = m->next);
 		m->next = mon->next;
 	}
+	for (size_t i = 0; i < NUMTAGS; i++)
+		if (mon->tagmap[i])
+			XFreePixmap(dpy, mon->tagmap[i]);
+	XUnmapWindow(dpy, mon->tagwin);
+	XDestroyWindow(dpy, mon->tagwin);
 	XUnmapWindow(dpy, mon->barwin);
 	XDestroyWindow(dpy, mon->barwin);
 	free(mon->pertag);
@@ -1651,6 +1665,13 @@ grabkeys(void)
 	}
 }
 
+void
+hidetagpreview(Monitor *m)
+{
+	m->previewshow = 0;
+	XUnmapWindow(dpy, m->tagwin);
+}
+
 #ifdef XINERAMA
 static int
 isuniquegeom(XineramaScreenInfo *unique, size_t n, XineramaScreenInfo *info)
@@ -1854,8 +1875,41 @@ void
 motionnotify(XEvent *e)
 {
 	static Monitor *mon = NULL;
-	Monitor *m;
+	Monitor *m = selmon;
 	XMotionEvent *ev = &e->xmotion;
+	int i, x, px, py, tsize;
+	int ov = gappov;
+	int oh = gappoh;
+
+	if (ev->window == selmon->barwin) {
+        i = x = tsize = 0;
+        for (i = 0; i < LENGTH(tags); i++) {
+            tsize += TEXTW(tags[i]);
+        }
+
+        x = (m->ww - tsize) / 2;
+        i = 0;
+
+		do
+			x += TEXTW(tags[i]);
+		while (ev->x >= x && ++i < NUMTAGS);
+
+		if (i < NUMTAGS) {
+			if ((i + 1) != selmon->previewshow && !(selmon->tagset[selmon->seltags] & 1 << i)) {
+				py = vertpad + bh + oh;
+				px = sidepad + ev->x - m->mw / scalepreview / 2;
+				if (px + m->mw / scalepreview > m->mx + m->mw)
+					px = m->wx + m->ww - m->mw / scalepreview - ov;
+				else if (px < sidepad)
+					px = m->wx + ov;
+
+				selmon->previewshow = i + 1;
+				showtagpreview(i, px, py);
+			} else if (selmon->tagset[selmon->seltags] & 1 << i)
+				hidetagpreview(selmon);
+		}
+	} else if (selmon->previewshow != 0)
+		hidetagpreview(selmon);
 
 	if (ev->window != root)
 		return;
@@ -1864,6 +1918,7 @@ motionnotify(XEvent *e)
 		selmon = m;
 		focus(NULL);
 	}
+
 	mon = m;
 }
 
@@ -2808,6 +2863,7 @@ setup(void)
 	/* init bars */
 	updatebars();
 	updatestatus();
+	updatepreview();
 	updatebarpos(selmon);
 	/* supporting window for NetWMCheck */
 	wmcheckwin = XCreateSimpleWindow(dpy, root, 0, 0, 1, 1, 0, 0, 0);
@@ -2880,6 +2936,19 @@ sigchld(int unused)
 	if (signal(SIGCHLD, sigchld) == SIG_ERR)
 		die("can't install SIGCHLD handler:");
 	while (0 < waitpid(-1, NULL, WNOHANG));
+}
+
+void
+showtagpreview(int tag, int x, int y)
+{
+	if (selmon->tagmap[tag]) {
+		XSetWindowBackgroundPixmap(dpy, selmon->tagwin, selmon->tagmap[tag]);
+		XCopyArea(dpy, selmon->tagmap[tag], selmon->tagwin, drw->gc, 0, 0, selmon->mw / scalepreview, selmon->mh / scalepreview, 0, 0);
+		XMoveWindow(dpy, selmon->tagwin, x, y);
+		XSync(dpy, False);
+		XMapWindow(dpy, selmon->tagwin);
+	} else
+		XUnmapWindow(dpy, selmon->tagwin);
 }
 
 void
@@ -3047,6 +3116,7 @@ toggleview(const Arg *arg)
 	int i;
 
 	if (newtagset) {
+		tagpreviewswitchtag();
 		selmon->tagset[selmon->seltags] = newtagset;
 
 		if (newtagset == ~0) {
@@ -3073,6 +3143,63 @@ toggleview(const Arg *arg)
 
 		focus(NULL);
 		arrange(selmon);
+	}
+}
+
+void
+tagpreviewswitchtag(void)
+{
+	int i;
+	unsigned int occ = 0;
+	Client *c;
+	Imlib_Image image;
+
+	for (c = selmon->clients; c; c = c->next)
+		occ |= c->tags;
+	for (i = 0; i < NUMTAGS; i++) {
+		if (selmon->tagset[selmon->seltags] & 1 << i) {
+					if (selmon->tagmap[i] != 0) {
+				XFreePixmap(dpy, selmon->tagmap[i]);
+				selmon->tagmap[i] = 0;
+			}
+			if (occ & 1 << i) {
+				image = imlib_create_image(sw, sh);
+				imlib_context_set_image(image);
+				imlib_context_set_display(dpy);
+				imlib_image_set_has_alpha(1);
+				imlib_context_set_blend(0);
+				imlib_context_set_visual(visual);
+				imlib_context_set_drawable(root);
+				imlib_copy_drawable_to_image(0, selmon->mx, selmon->my, selmon->mw ,selmon->mh, 0, 0, 1);
+				selmon->tagmap[i] = XCreatePixmap(dpy, selmon->tagwin, selmon->mw / scalepreview, selmon->mh / scalepreview, depth);
+				imlib_context_set_drawable(selmon->tagmap[i]);
+				imlib_render_image_part_on_drawable_at_size(0, 0, selmon->mw, selmon->mh, 0, 0, selmon->mw / scalepreview, selmon->mh / scalepreview);
+				imlib_free_image();
+			}
+		}
+	}
+}
+
+void
+updatepreview(void)
+{
+	Monitor *m;
+
+	XSetWindowAttributes wa = {
+		.override_redirect = True,
+		.background_pixel = 0,
+		.border_pixel = 0,
+		.colormap = cmap,
+		.event_mask = ButtonPressMask|ExposureMask
+	};
+	for (m = mons; m; m = m->next) {
+		m->tagwin = XCreateWindow(dpy, root, m->wx, m->by + bh, m->mw / 4, m->mh / 4, 0,
+				depth, CopyFromParent, visual,
+				CWOverrideRedirect|CWBackPixel|CWBorderPixel|CWColormap|CWEventMask, &wa
+				);
+		XDefineCursor(dpy, m->tagwin, cursor[CurNormal]->cursor);
+		XMapRaised(dpy, m->tagwin);
+		XUnmapWindow(dpy, m->tagwin);
 	}
 }
 
@@ -3155,7 +3282,7 @@ updatebars(void)
 		.background_pixel = 0,
 		.border_pixel = 0,
 		.colormap = cmap,
-		.event_mask = ButtonPressMask|ExposureMask
+		.event_mask = ButtonPressMask|ExposureMask|PointerMotionMask
 	};
 	XClassHint ch = {"hydra", "hydra"};
 	for (m = mons; m; m = m->next) {
@@ -3450,6 +3577,7 @@ view(const Arg *arg)
 
 	if ((arg->ui & TAGMASK) == selmon->tagset[selmon->seltags])
 		return;
+	tagpreviewswitchtag();
 	selmon->seltags ^= 1; /* toggle sel tagset */
 	if (arg->ui & TAGMASK) {
 		selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;


### PR DESCRIPTION
adds tagpreview patch to hydra
there's still a bug where hovering on the right side of the bar will try to show the first tag (doesnt crash)
it's most likely some geometry stuff in motionnotify()